### PR TITLE
Remove archived components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,23 @@
 import './App.css';
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
-import { ActivityFeed } from './components/ActivityFeed';
 import { BudgetLineSummary } from './components/BudgetLineSummary';
 import { FilterBar } from './components/FilterBar';
 import { Header } from './components/Header';
-import { SummaryProgressBars } from './components/SummaryProgressBars';
 import { TransactionList } from './components/TransactionList';
 import { TransactionModal } from './components/TransactionModal';
 import { LedgerProvider } from './context/LedgerContext';
 
 const Dashboard = () => {
   const [modalOpen, setModalOpen] = useState(false);
-  const tableRef = useRef<HTMLDivElement>(null);
-
-  const scrollToTable = () => {
-    tableRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
 
   return (
     <div className="wl-app">
       <Header onAddTransaction={() => setModalOpen(true)} />
       <main className="wl-main">
-        <SummaryProgressBars />
         <BudgetLineSummary />
-        <ActivityFeed onViewAll={scrollToTable} />
-        <div ref={tableRef}>
-          <FilterBar />
-        </div>
+        <FilterBar />
         <TransactionList />
       </main>
       <TransactionModal isOpen={modalOpen} onClose={() => setModalOpen(false)} />

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,11 +1,7 @@
 import { useLedger } from '../hooks/useLedger';
-import { FilterType } from '../types';
-
-const FILTERS: FilterType[] = ['All', 'Inflow', 'Outflow', 'Flagged', 'Submitted'];
 
 export const FilterBar = () => {
-  const { activeFilter, setActiveFilter, selectedBudgetLine, filteredTransactions } =
-    useLedger();
+  const { selectedBudgetLine, filteredTransactions } = useLedger();
 
   const label = selectedBudgetLine
     ? `${selectedBudgetLine} — ${filteredTransactions.length} transactions`
@@ -14,19 +10,6 @@ export const FilterBar = () => {
   return (
     <div className="wl-filter-bar">
       <span className="wl-filter-label">{label}</span>
-      <div className="wl-filter-buttons" role="group" aria-label="Filter transactions">
-        {FILTERS.map((filter) => (
-          <button
-            key={filter}
-            type="button"
-            className={`wl-filter-btn${activeFilter === filter ? ' wl-filter-btn--active' : ''}`}
-            onClick={() => setActiveFilter(filter)}
-            aria-pressed={activeFilter === filter}
-          >
-            {filter}
-          </button>
-        ))}
-      </div>
     </div>
   );
 };

--- a/src/components/_archived/ActivityFeed.tsx
+++ b/src/components/_archived/ActivityFeed.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+
+import { useLedger } from '../hooks/useLedger';
+import { Transaction } from '../types';
+import { formatCurrency, isTransactionFlagged } from '../utilities/calculations';
+
+const ActivityItem = ({ transaction: t }: { transaction: Transaction }) => {
+  const isInflow = t.direction === 'Inflow';
+  const flagged = isTransactionFlagged(t);
+
+  return (
+    <div className={`wl-activity-item${flagged ? ' wl-activity-item--flagged' : ''}`}>
+      <div
+        className={`wl-activity-arrow${isInflow ? ' wl-activity-arrow--in' : ' wl-activity-arrow--out'}`}
+        aria-hidden="true"
+      >
+        {isInflow ? '↑' : '↓'}
+      </div>
+      <div className="wl-activity-info">
+        <span className="wl-activity-title">{t.title}</span>
+        <span className="wl-activity-meta">
+          {t.date} · {t.budgetLine} · {t.person}
+        </span>
+      </div>
+      <div className="wl-activity-right">
+        <span
+          className={`wl-activity-amount${isInflow ? ' wl-amount-positive' : ' wl-amount-negative'}`}
+        >
+          {isInflow ? '+' : '-'}
+          {formatCurrency(t.amount)}
+        </span>
+        {flagged && (
+          <span className="wl-flag-dot" aria-label="Incomplete">
+            !
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface ActivityFeedProps {
+  onViewAll: () => void;
+}
+
+export const ActivityFeed = ({ onViewAll }: ActivityFeedProps) => {
+  const { transactions } = useLedger();
+  const [expanded, setExpanded] = useState(false);
+
+  const recent = [...transactions]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 5);
+
+  const handleViewAll = () => {
+    setExpanded(true);
+    onViewAll();
+  };
+
+  return (
+    <div className="wl-card">
+      <div className="wl-card-title-row">
+        <h2 className="wl-card-title">Recent Activity</h2>
+        <span className="wl-activity-count">
+          {recent.length} of {transactions.length}
+        </span>
+      </div>
+      <div className="wl-activity-list">
+        {recent.map((t) => (
+          <ActivityItem key={t.id} transaction={t} />
+        ))}
+      </div>
+      {transactions.length > 5 && (
+        <button
+          type="button"
+          className="wl-btn-view-all"
+          onClick={handleViewAll}
+          aria-expanded={expanded}
+        >
+          View all transactions →
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/_archived/SummaryProgressBars.tsx
+++ b/src/components/_archived/SummaryProgressBars.tsx
@@ -1,0 +1,70 @@
+import { useLedger } from '../hooks/useLedger';
+import { formatCurrency } from '../utilities/calculations';
+
+type ProgressVariant = 'balance' | 'inflow' | 'outflow';
+
+interface ProgressBarProps {
+  label: string;
+  value: number;
+  max: number;
+  formatted: string;
+  variant: ProgressVariant;
+}
+
+const ProgressBar = ({ label, value, max, formatted, variant }: ProgressBarProps) => {
+  const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+  return (
+    <div className="wl-progress-item">
+      <div className="wl-progress-header">
+        <span className="wl-progress-label">{label}</span>
+        <span className={`wl-progress-value wl-progress-value--${variant}`}>
+          {formatted}
+        </span>
+      </div>
+      <div
+        className="wl-progress-track"
+        role="progressbar"
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label}
+      >
+        <div
+          className={`wl-progress-fill wl-progress-fill--${variant}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const SummaryProgressBars = () => {
+  const { overallSummary } = useLedger();
+  const { totalBalance, totalInflow, totalOutflow } = overallSummary;
+
+  return (
+    <section aria-label="Financial summary" className="wl-card wl-progress-section">
+      <ProgressBar
+        label="Total Balance"
+        value={totalBalance}
+        max={totalInflow}
+        formatted={formatCurrency(totalBalance)}
+        variant="balance"
+      />
+      <ProgressBar
+        label="Total Inflow"
+        value={totalInflow}
+        max={totalInflow}
+        formatted={`+${formatCurrency(totalInflow)}`}
+        variant="inflow"
+      />
+      <ProgressBar
+        label="Total Outflow"
+        value={totalOutflow}
+        max={totalInflow}
+        formatted={`-${formatCurrency(totalOutflow)}`}
+        variant="outflow"
+      />
+    </section>
+  );
+};


### PR DESCRIPTION
                                                                                                                                                           
  ---                                                                                                                                                          
  Simplify dashboard — archive unused components and remove filter bar controls
                                                                                                                                                               
  Summary         
                                                                                                                                                               
  - Moved ActivityFeed and SummaryProgressBars to src/components/_archived/ to preserve the code without cluttering the active component directory             
  - Removed both components from App.tsx, along with the now-unused useRef, tableRef, and scrollToTable logic that only existed to support ActivityFeed
  - Stripped the Inflow / Outflow / Flagged / Submitted filter buttons from FilterBar, leaving only the transaction count label — the dashboard now always     
  shows all transactions                                                                                                                                       
                                                                                                                                                               
  What's still in place                                                                                                                                        
                  
  - The activeFilter / setActiveFilter state remains in LedgerContext in case filtering is reintroduced later
  - Budget line filtering via BudgetLineSummary cards is unchanged