### PR TITLE
Feature/budget setup flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom
 import { AuthProvider } from './context/AuthContext';
 import { LedgerProvider } from './context/LedgerContext';
 import { useAuth } from './hooks/useAuth';
+import { CreateOrganization } from './pages/CreateOrganization';
 import { Dashboard } from './pages/Dashboard';
 import { LoginPage } from './pages/LoginPage';
 import { OrganizationsPage } from './pages/OrganizationsPage';
@@ -27,6 +28,7 @@ const App = () => (
         <Route path="/login" element={<LoginPage />} />
         <Route element={<ProtectedLayout />}>
           <Route path="/organizations" element={<OrganizationsPage />} />
+          <Route path="/budget-setup" element={<CreateOrganization />} />
           <Route path="/dashboard" element={<Dashboard />} />
         </Route>
         <Route path="*" element={<Navigate to="/login" replace />} />

--- a/src/context/LedgerContext.tsx
+++ b/src/context/LedgerContext.tsx
@@ -95,6 +95,7 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
                 name: data.name as string,
                 admins: (data.admins ?? []) as string[],
                 budgetAllocations: data.budgetAllocations as BudgetAllocations,
+                isBudgetLineSet: (data.isBudgetLineSet as boolean) ?? false,
                 transactions,
               };
             }),
@@ -209,6 +210,14 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
     await updateDoc(orgRef, { budgetAllocations: allocations });
   };
 
+  // Sets the initial budget allocations and locks the flag so it cannot be
+  // done again through the normal onboarding flow.
+  const initializeBudgetAllocations = async (allocations: BudgetAllocations) => {
+    if (!activeOrganizationId) return;
+    const orgRef = doc(db, 'clubs', activeOrganizationId);
+    await updateDoc(orgRef, { budgetAllocations: allocations, isBudgetLineSet: true });
+  };
+
   const activeOrganization =
     organizations.find((o: Organization) => o.id === activeOrganizationId) ?? null;
 
@@ -240,6 +249,7 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
     updateTransaction,
     deleteTransaction,
     updateBudgetAllocations,
+    initializeBudgetAllocations,
     selectedBudgetLine,
     setSelectedBudgetLine,
     filteredTransactions,

--- a/src/pages/CreateOrganization.tsx
+++ b/src/pages/CreateOrganization.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useLedger } from '../hooks/useLedger';
@@ -13,12 +13,25 @@ const EMPTY_ALLOCATIONS: BudgetAllocations = {
 };
 
 export const CreateOrganization = () => {
-  const { addOrganization, organizations } = useLedger();
+  const { activeOrganization, initializeBudgetAllocations } = useLedger();
   const navigate = useNavigate();
 
-  const [orgName, setOrgName] = useState('');
   const [allocations, setAllocations] = useState<BudgetAllocations>(EMPTY_ALLOCATIONS);
   const [rawInputs, setRawInputs] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Guard: no active org selected — send back to org picker
+  useEffect(() => {
+    if (!activeOrganization) {
+      navigate('/organizations', { replace: true });
+      return;
+    }
+    // Guard: budget already initialized — skip straight to dashboard
+    if (activeOrganization.isBudgetLineSet) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [activeOrganization, navigate]);
 
   const setAllocation = (line: keyof BudgetAllocations, raw: string) => {
     if (!/^\d*\.?\d{0,2}$/.test(raw)) return;
@@ -27,61 +40,35 @@ export const CreateOrganization = () => {
     setAllocations((prev) => ({ ...prev, [line]: isNaN(val) ? 0 : val }));
   };
 
-  const [error, setError] = useState<string | null>(null);
-
   const handleSubmit = async () => {
-    const name = orgName.trim();
-    if (!name) {
-      setError('Organization name is required.');
-      return;
-    }
-    const duplicate = organizations.some(
-      (o) => o.name.trim().toLowerCase() === name.toLowerCase(),
-    );
-    if (duplicate) {
-      setError(`An organization named "${name}" already exists.`);
-      return;
-    }
     const missingLines = BUDGET_LINES.filter(
       (line) => rawInputs[line] === undefined || rawInputs[line] === '',
     );
     if (missingLines.length > 0) {
-      setError(`Please enter a value for: ${missingLines.join(', ')}.`);
+      setError(`Please enter a starting amount for: ${missingLines.join(', ')}.`);
       return;
     }
     setError(null);
+    setSubmitting(true);
     try {
-      await addOrganization(name, allocations);
-      navigate('/');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create organization.');
+      await initializeBudgetAllocations(allocations);
+      navigate('/dashboard', { replace: true });
+    } catch {
+      setError('Failed to save budget allocations. Please try again.');
+      setSubmitting(false);
     }
   };
+
+  if (!activeOrganization) return null;
 
   return (
     <div className="wl-register-root">
       <div className="wl-register-card">
         <h1 className="wl-register-title">WildcatLedger</h1>
         <p className="wl-register-subtitle">
-          Set up your organization&apos;s budget allocations to get started.
+          Set starting budget amounts for <strong>{activeOrganization.name}</strong>.
         </p>
         <div className="wl-budget-allocation-form">
-          <div className="wl-budget-allocation-row">
-            <label className="wl-budget-allocation-label" htmlFor="org-name">
-              Organization Name
-            </label>
-            <div className="wl-budget-allocation-input-wrap">
-              <input
-                id="org-name"
-                type="text"
-                className="wl-form-input"
-                value={orgName}
-                placeholder="Enter organization name"
-                onChange={(e) => setOrgName(e.target.value)}
-              />
-            </div>
-            <span className="wl-budget-allocation-preview" />
-          </div>
           {BUDGET_LINES.map((line) => (
             <div key={line} className="wl-budget-allocation-row">
               <label className="wl-budget-allocation-label" htmlFor={`budget-${line}`}>
@@ -114,8 +101,9 @@ export const CreateOrganization = () => {
           type="button"
           className="wl-btn-primary wl-register-done"
           onClick={handleSubmit}
+          disabled={submitting}
         >
-          Create Organization
+          {submitting ? 'Saving…' : 'Save & Continue'}
         </button>
       </div>
     </div>

--- a/src/pages/OrganizationsPage.tsx
+++ b/src/pages/OrganizationsPage.tsx
@@ -1,14 +1,19 @@
 import { useNavigate } from 'react-router-dom';
 
 import { useLedger } from '../hooks/useLedger';
+import { Organization } from '../types';
 
 export const OrganizationsPage = () => {
   const { organizations, setActiveOrganizationId } = useLedger();
   const navigate = useNavigate();
 
-  const handleSelectOrg = (id: string) => {
-    setActiveOrganizationId(id);
-    navigate('/dashboard');
+  const handleSelectOrg = (org: Organization) => {
+    setActiveOrganizationId(org.id);
+    if (org.isBudgetLineSet) {
+      navigate('/dashboard');
+    } else {
+      navigate('/budget-setup');
+    }
   };
 
   return (
@@ -19,9 +24,7 @@ export const OrganizationsPage = () => {
           <p className="wl-onboarding-tagline">
             Track and manage your club&apos;s finances
           </p>
-          <p className="wl-register-subtitle">
-            Create or select an organization to get started
-          </p>
+          <p className="wl-register-subtitle">Select an organization to get started</p>
         </div>
         <div className="wl-org-grid">
           {organizations.map((org) => (
@@ -29,7 +32,7 @@ export const OrganizationsPage = () => {
               key={org.id}
               type="button"
               className="wl-org-card"
-              onClick={() => handleSelectOrg(org.id)}
+              onClick={() => handleSelectOrg(org)}
             >
               <span className="wl-org-card-name">{org.name}</span>
             </button>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface Organization {
   name: string;
   admins: string[];
   budgetAllocations: BudgetAllocations;
+  isBudgetLineSet: boolean;
   transactions: Transaction[];
 }
 
@@ -64,6 +65,7 @@ export interface LedgerContextValue {
   updateTransaction: (id: string, transaction: Omit<Transaction, 'id'>) => Promise<void>;
   deleteTransaction: (id: string) => Promise<void>;
   updateBudgetAllocations: (allocations: BudgetAllocations) => Promise<void>;
+  initializeBudgetAllocations: (allocations: BudgetAllocations) => Promise<void>;
   selectedBudgetLine: BudgetLine | null;
   setSelectedBudgetLine: (line: BudgetLine | null) => void;
   filteredTransactions: Transaction[];


### PR DESCRIPTION
On first org click, route to /budget-setup to set initial allocations.
On submit, write allocations and flip isBudgetLineSet to true in Firestore.
Subsequent logins skip setup and go straight to /dashboard.