### PR TITLE
Wip/role permissions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1268,6 +1268,74 @@ tbody tr:hover:not(.wl-row--flagged) {
   background: #fafafa;
 }
 
+.wl-row--pending {
+  background: #fffbeb;
+}
+
+.wl-row--pending:hover {
+  background: #fef3c7;
+}
+
+.wl-pending-type-badge {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #92400e;
+  margin-top: 2px;
+  letter-spacing: 0.01em;
+}
+
+.wl-pending-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #92400e;
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.wl-approve-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.wl-btn-approve {
+  background: var(--color-positive);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.wl-btn-approve:hover {
+  opacity: 0.85;
+}
+
+.wl-btn-reject {
+  background: none;
+  color: var(--color-negative);
+  border: 1.5px solid var(--color-negative);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.wl-btn-reject:hover {
+  background: var(--color-negative);
+  color: #fff;
+}
+
 tbody tr:last-child .wl-td {
   border-bottom: none;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1538,6 +1538,18 @@ tbody tr:last-child .wl-td {
   border-left-color: var(--color-negative);
 }
 
+.wl-audit-entry--request {
+  border-left-color: #f59e0b;
+}
+
+.wl-audit-entry--approve {
+  border-left-color: #10b981;
+}
+
+.wl-audit-entry--reject {
+  border-left-color: #ef4444;
+}
+
 .wl-audit-entry-header {
   display: flex;
   align-items: center;
@@ -1576,6 +1588,21 @@ tbody tr:last-child .wl-td {
 .wl-audit-badge--delete {
   background: var(--color-flag-bg);
   color: var(--color-flag-text);
+}
+
+.wl-audit-badge--request {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.wl-audit-badge--approve {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.wl-audit-badge--reject {
+  background: #fee2e2;
+  color: #991b1b;
 }
 
 .wl-audit-title {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,7 @@ interface HeaderProps {
 }
 
 export const Header = ({ onAddTransaction }: HeaderProps) => {
-  const { activeOrganization } = useLedger();
+  const { activeOrganization, userRole } = useLedger();
   const navigate = useNavigate();
 
   return (
@@ -19,9 +19,11 @@ export const Header = ({ onAddTransaction }: HeaderProps) => {
           </h1>
         </div>
         <div className="wl-header-right">
-          <button type="button" className="wl-btn-add" onClick={onAddTransaction}>
-            + Add Transaction
-          </button>
+          {userRole !== 'exec' && (
+            <button type="button" className="wl-btn-add" onClick={onAddTransaction}>
+              + Add Transaction
+            </button>
+          )}
           <button
             type="button"
             className="wl-btn-header-icon"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ export const Header = ({ onAddTransaction }: HeaderProps) => {
           </h1>
         </div>
         <div className="wl-header-right">
-          {userRole !== 'exec' && (
+          {(userRole === 'treasurer' || userRole === 'president') && (
             <button type="button" className="wl-btn-add" onClick={onAddTransaction}>
               + Add Transaction
             </button>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -59,7 +59,7 @@ const TransactionRow = ({
 
 export const TransactionList = () => {
   const { filteredTransactions, deleteTransaction, userRole } = useLedger();
-  const canEdit = userRole !== 'exec';
+  const canEdit = userRole === 'treasurer' || userRole === 'president';
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(
     null,

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,27 +1,42 @@
 import { useState } from 'react';
 
+import { auth } from '../config/firebase';
 import { useLedger } from '../hooks/useLedger';
-import { Transaction } from '../types';
+import { PendingChange, Transaction } from '../types';
 import { formatCurrency } from '../utilities/calculations';
 import { TransactionModal } from './TransactionModal';
 
 const TransactionRow = ({
   t,
+  canEdit,
+  pending,
   onEdit,
   onDelete,
-  canEdit,
+  onApprove,
+  onReject,
 }: {
   t: Transaction;
+  canEdit: boolean;
+  pending: PendingChange | undefined;
   onEdit: (t: Transaction) => void;
   onDelete: (t: Transaction) => void;
-  canEdit: boolean;
+  onApprove: (pendingId: string) => void;
+  onReject: (pendingId: string) => void;
 }) => {
   const isInflow = t.direction === 'Inflow';
+  const currentEmail = auth.currentUser?.email;
+  const isMyPending = !!pending && pending.requestedBy === currentEmail;
+  const canApprove = !!pending && !isMyPending && canEdit;
 
   return (
-    <tr>
+    <tr className={pending ? 'wl-row--pending' : ''}>
       <td className="wl-td wl-td-title">
         <span className="wl-td-title-text">{t.title}</span>
+        {pending && (
+          <span className="wl-pending-type-badge">
+            {pending.type === 'delete' ? 'Delete requested' : 'Edit requested'}
+          </span>
+        )}
       </td>
       <td
         className={`wl-td wl-td-amount ${isInflow ? 'wl-amount-positive' : 'wl-amount-negative'}`}
@@ -35,22 +50,47 @@ const TransactionRow = ({
       </td>
       {canEdit && (
         <td className="wl-td wl-td-actions">
-          <button
-            type="button"
-            className="wl-action-btn"
-            onClick={() => onEdit(t)}
-            aria-label="Edit transaction"
-          >
-            ✎
-          </button>
-          <button
-            type="button"
-            className="wl-action-btn wl-action-btn--delete"
-            onClick={() => onDelete(t)}
-            aria-label="Delete transaction"
-          >
-            ✕
-          </button>
+          {pending ? (
+            isMyPending ? (
+              <span className="wl-pending-badge">Awaiting Approval</span>
+            ) : canApprove ? (
+              <div className="wl-approve-actions">
+                <button
+                  type="button"
+                  className="wl-btn-approve"
+                  onClick={() => onApprove(pending.id)}
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  className="wl-btn-reject"
+                  onClick={() => onReject(pending.id)}
+                >
+                  Reject
+                </button>
+              </div>
+            ) : null
+          ) : (
+            <>
+              <button
+                type="button"
+                className="wl-action-btn"
+                onClick={() => onEdit(t)}
+                aria-label="Edit transaction"
+              >
+                ✎
+              </button>
+              <button
+                type="button"
+                className="wl-action-btn wl-action-btn--delete"
+                onClick={() => onDelete(t)}
+                aria-label="Delete transaction"
+              >
+                ✕
+              </button>
+            </>
+          )}
         </td>
       )}
     </tr>
@@ -58,7 +98,14 @@ const TransactionRow = ({
 };
 
 export const TransactionList = () => {
-  const { filteredTransactions, deleteTransaction, userRole } = useLedger();
+  const {
+    filteredTransactions,
+    deleteTransaction,
+    userRole,
+    pendingChanges,
+    approvePendingChange,
+    rejectPendingChange,
+  } = useLedger();
   const canEdit = userRole === 'treasurer' || userRole === 'president';
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(
@@ -98,9 +145,12 @@ export const TransactionList = () => {
                 <TransactionRow
                   key={t.id}
                   t={t}
+                  canEdit={canEdit}
+                  pending={pendingChanges.find((p) => p.transactionId === t.id)}
                   onEdit={setEditingTransaction}
                   onDelete={setDeletingTransaction}
-                  canEdit={canEdit}
+                  onApprove={approvePendingChange}
+                  onReject={rejectPendingChange}
                 />
               ))}
             </tbody>
@@ -111,7 +161,8 @@ export const TransactionList = () => {
       {deletingTransaction && (
         <div className="wl-inline-confirm">
           <p>
-            Delete <strong>{deletingTransaction.title}</strong>? This cannot be undone.
+            Submit a delete request for <strong>{deletingTransaction.title}</strong>? The
+            other approver will need to confirm before it is removed.
           </p>
           <div className="wl-overdraft-actions">
             <button
@@ -120,7 +171,7 @@ export const TransactionList = () => {
               style={{ background: '#dc2626' }}
               onClick={handleDeleteConfirm}
             >
-              Delete
+              Submit Request
             </button>
             <button
               type="button"

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -9,10 +9,12 @@ const TransactionRow = ({
   t,
   onEdit,
   onDelete,
+  canEdit,
 }: {
   t: Transaction;
   onEdit: (t: Transaction) => void;
   onDelete: (t: Transaction) => void;
+  canEdit: boolean;
 }) => {
   const isInflow = t.direction === 'Inflow';
 
@@ -31,30 +33,33 @@ const TransactionRow = ({
       <td className="wl-td wl-td-budget">
         <span className="wl-budget-chip">{t.budgetLine}</span>
       </td>
-      <td className="wl-td wl-td-actions">
-        <button
-          type="button"
-          className="wl-action-btn"
-          onClick={() => onEdit(t)}
-          aria-label="Edit transaction"
-        >
-          ✎
-        </button>
-        <button
-          type="button"
-          className="wl-action-btn wl-action-btn--delete"
-          onClick={() => onDelete(t)}
-          aria-label="Delete transaction"
-        >
-          ✕
-        </button>
-      </td>
+      {canEdit && (
+        <td className="wl-td wl-td-actions">
+          <button
+            type="button"
+            className="wl-action-btn"
+            onClick={() => onEdit(t)}
+            aria-label="Edit transaction"
+          >
+            ✎
+          </button>
+          <button
+            type="button"
+            className="wl-action-btn wl-action-btn--delete"
+            onClick={() => onDelete(t)}
+            aria-label="Delete transaction"
+          >
+            ✕
+          </button>
+        </td>
+      )}
     </tr>
   );
 };
 
 export const TransactionList = () => {
-  const { filteredTransactions, deleteTransaction } = useLedger();
+  const { filteredTransactions, deleteTransaction, userRole } = useLedger();
+  const canEdit = userRole !== 'exec';
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [deletingTransaction, setDeletingTransaction] = useState<Transaction | null>(
     null,
@@ -85,7 +90,7 @@ export const TransactionList = () => {
                 <th className="wl-th">Amount</th>
                 <th className="wl-th">Type</th>
                 <th className="wl-th">Budget Line</th>
-                <th className="wl-th">Actions</th>
+                {canEdit && <th className="wl-th">Actions</th>}
               </tr>
             </thead>
             <tbody>
@@ -95,6 +100,7 @@ export const TransactionList = () => {
                   t={t}
                   onEdit={setEditingTransaction}
                   onDelete={setDeletingTransaction}
+                  canEdit={canEdit}
                 />
               ))}
             </tbody>

--- a/src/context/LedgerContext.tsx
+++ b/src/context/LedgerContext.tsx
@@ -84,12 +84,14 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
             .filter((doc) => {
               const data = doc.data();
               const admins: string[] = data.admins ?? [];
-              const execs: string[] = data.execs ?? [];
+              const officers: string[] = data.officers ?? [];
+              const treasurers: string[] = data.treasurers ?? [];
+              const presidents: string[] = data.presidents ?? [];
               return (
                 admins.includes(userEmail) ||
-                data.treasurer === userEmail ||
-                data.president === userEmail ||
-                execs.includes(userEmail)
+                treasurers.includes(userEmail) ||
+                presidents.includes(userEmail) ||
+                officers.includes(userEmail)
               );
             })
             .map(async (doc) => {
@@ -105,9 +107,9 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
                 id: doc.id,
                 name: data.name as string,
                 admins: (data.admins ?? []) as string[],
-                treasurer: data.treasurer as string | undefined,
-                president: data.president as string | undefined,
-                execs: (data.execs ?? []) as string[],
+                treasurer: (data.treasurers ?? []) as string[],
+                president: (data.presidents ?? []) as string[],
+                officers: (data.officers ?? []) as string[],
                 budgetAllocations: data.budgetAllocations as BudgetAllocations,
                 isBudgetLinesSet: (data.isBudgetLinesSet as boolean) ?? false,
                 transactions,
@@ -279,18 +281,13 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
   const activeOrganization =
     organizations.find((o: Organization) => o.id === activeOrganizationId) ?? null;
 
-  const [currentUserEmail, setCurrentUserEmail] = useState<string | null>(null);
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => setCurrentUserEmail(u?.email ?? null));
-    return unsub;
-  }, []);
-
   const userRole = ((): UserRole | null => {
-    if (!currentUserEmail || !activeOrganization) return null;
-    if (activeOrganization.treasurer === currentUserEmail) return 'treasurer';
-    if (activeOrganization.president === currentUserEmail) return 'president';
-    if (activeOrganization.execs?.includes(currentUserEmail)) return 'exec';
-    if (activeOrganization.admins?.includes(currentUserEmail)) return 'treasurer';
+    const email = auth.currentUser?.email;
+    if (!email || !activeOrganization) return null;
+    if (activeOrganization.treasurer?.includes(email)) return 'treasurer';
+    if (activeOrganization.president?.includes(email)) return 'president';
+    if (activeOrganization.officers?.includes(email)) return 'officer';
+    if (activeOrganization.admins?.includes(email)) return 'treasurer';
     return null;
   })();
 

--- a/src/context/LedgerContext.tsx
+++ b/src/context/LedgerContext.tsx
@@ -21,6 +21,7 @@ import {
   LedgerContextValue,
   Organization,
   Transaction,
+  UserRole,
 } from '../types';
 import {
   applyFilters,
@@ -81,8 +82,15 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
         const orgs: Organization[] = await Promise.all(
           snapshot.docs
             .filter((doc) => {
-              const admins: string[] = doc.data().admins ?? [];
-              return admins.includes(userEmail);
+              const data = doc.data();
+              const admins: string[] = data.admins ?? [];
+              const execs: string[] = data.execs ?? [];
+              return (
+                admins.includes(userEmail) ||
+                data.treasurer === userEmail ||
+                data.president === userEmail ||
+                execs.includes(userEmail)
+              );
             })
             .map(async (doc) => {
               const data = doc.data();
@@ -97,6 +105,9 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
                 id: doc.id,
                 name: data.name as string,
                 admins: (data.admins ?? []) as string[],
+                treasurer: data.treasurer as string | undefined,
+                president: data.president as string | undefined,
+                execs: (data.execs ?? []) as string[],
                 budgetAllocations: data.budgetAllocations as BudgetAllocations,
                 isBudgetLinesSet: (data.isBudgetLinesSet as boolean) ?? false,
                 transactions,
@@ -268,6 +279,21 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
   const activeOrganization =
     organizations.find((o: Organization) => o.id === activeOrganizationId) ?? null;
 
+  const [currentUserEmail, setCurrentUserEmail] = useState<string | null>(null);
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => setCurrentUserEmail(u?.email ?? null));
+    return unsub;
+  }, []);
+
+  const userRole = ((): UserRole | null => {
+    if (!currentUserEmail || !activeOrganization) return null;
+    if (activeOrganization.treasurer === currentUserEmail) return 'treasurer';
+    if (activeOrganization.president === currentUserEmail) return 'president';
+    if (activeOrganization.execs?.includes(currentUserEmail)) return 'exec';
+    if (activeOrganization.admins?.includes(currentUserEmail)) return 'treasurer';
+    return null;
+  })();
+
   const transactions = activeOrganization?.transactions ?? [];
   const budgetAllocations = activeOrganization?.budgetAllocations ?? EMPTY_ALLOCATIONS;
 
@@ -293,6 +319,7 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
     activeOrganizationId,
     setActiveOrganizationId,
     activeOrganization,
+    userRole,
     addTransaction,
     updateTransaction,
     deleteTransaction,

--- a/src/context/LedgerContext.tsx
+++ b/src/context/LedgerContext.tsx
@@ -20,6 +20,7 @@ import {
   BudgetLine,
   LedgerContextValue,
   Organization,
+  PendingChange,
   Transaction,
   UserRole,
 } from '../types';
@@ -41,6 +42,7 @@ const EMPTY_ALLOCATIONS: BudgetAllocations = {
 export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [auditLog, setAuditLog] = useState<AuditEntry[]>([]);
+  const [pendingChanges, setPendingChanges] = useState<PendingChange[]>([]);
   const [activeOrganizationId, setActiveOrganizationIdState] = useState<string | null>(
     () => localStorage.getItem('activeOrganizationId'),
   );
@@ -149,9 +151,18 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
       setAuditLog(entries);
     });
 
+    const pendingRef = collection(db, 'clubs', activeOrganizationId, 'pendingChanges');
+    const unsubPending = onSnapshot(pendingRef, (snapshot) => {
+      const changes: PendingChange[] = snapshot.docs
+        .map((doc) => ({ id: doc.id, ...(doc.data() as Omit<PendingChange, 'id'>) }))
+        .sort((a, b) => b.requestedAt - a.requestedAt);
+      setPendingChanges(changes);
+    });
+
     return () => {
       unsubTxns();
       unsubAudit();
+      unsubPending();
     };
   }, [activeOrganizationId]);
 
@@ -238,30 +249,115 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
 
   const updateTransaction = async (id: string, transaction: Omit<Transaction, 'id'>) => {
     if (!activeOrganizationId) return;
+    const role = userRole;
+    if (role !== 'treasurer' && role !== 'president') return;
     const old = activeOrganization?.transactions.find((t) => t.id === id);
-    const txnRef = doc(db, 'clubs', activeOrganizationId, 'transactions', id);
-    await updateDoc(txnRef, toFirestore(transaction));
-    if (old)
-      await reverseDelta(activeOrganizationId, old.budgetLine, old.direction, old.amount);
-    await applyDelta(
-      activeOrganizationId,
-      transaction.budgetLine,
-      transaction.direction,
-      transaction.amount,
-    );
-    const oldWithoutId = old ? omitId(old) : null;
-    await writeAuditEntry('edit', id, transaction.title, oldWithoutId, transaction);
+    if (!old) return;
+    await addDoc(collection(db, 'clubs', activeOrganizationId, 'pendingChanges'), {
+      type: 'edit',
+      transactionId: id,
+      transactionTitle: transaction.title,
+      requestedBy: auth.currentUser?.email ?? 'unknown',
+      requestedByRole: role,
+      requestedAt: Date.now(),
+      before: toFirestore(omitId(old)),
+      after: toFirestore(transaction),
+    });
   };
 
   const deleteTransaction = async (id: string) => {
     if (!activeOrganizationId) return;
+    const role = userRole;
+    if (role !== 'treasurer' && role !== 'president') return;
     const old = activeOrganization?.transactions.find((t) => t.id === id);
-    const txnRef = doc(db, 'clubs', activeOrganizationId, 'transactions', id);
-    await deleteDoc(txnRef);
-    if (old)
-      await reverseDelta(activeOrganizationId, old.budgetLine, old.direction, old.amount);
-    const oldWithoutId = old ? omitId(old) : null;
-    await writeAuditEntry('delete', id, old?.title ?? '', oldWithoutId, null);
+    if (!old) return;
+    await addDoc(collection(db, 'clubs', activeOrganizationId, 'pendingChanges'), {
+      type: 'delete',
+      transactionId: id,
+      transactionTitle: old.title,
+      requestedBy: auth.currentUser?.email ?? 'unknown',
+      requestedByRole: role,
+      requestedAt: Date.now(),
+      before: toFirestore(omitId(old)),
+      after: null,
+    });
+  };
+
+  const approvePendingChange = async (pendingId: string) => {
+    if (!activeOrganizationId) return;
+    const pending = pendingChanges.find((p) => p.id === pendingId);
+    if (!pending) return;
+    const pendingRef = doc(
+      db,
+      'clubs',
+      activeOrganizationId,
+      'pendingChanges',
+      pendingId,
+    );
+    if (pending.type === 'edit' && pending.after) {
+      const txnRef = doc(
+        db,
+        'clubs',
+        activeOrganizationId,
+        'transactions',
+        pending.transactionId,
+      );
+      await updateDoc(txnRef, toFirestore(pending.after));
+      await reverseDelta(
+        activeOrganizationId,
+        pending.before.budgetLine,
+        pending.before.direction,
+        pending.before.amount,
+      );
+      await applyDelta(
+        activeOrganizationId,
+        pending.after.budgetLine,
+        pending.after.direction,
+        pending.after.amount,
+      );
+      await writeAuditEntry(
+        'edit',
+        pending.transactionId,
+        pending.transactionTitle,
+        pending.before,
+        pending.after,
+      );
+    } else if (pending.type === 'delete') {
+      const txnRef = doc(
+        db,
+        'clubs',
+        activeOrganizationId,
+        'transactions',
+        pending.transactionId,
+      );
+      await deleteDoc(txnRef);
+      await reverseDelta(
+        activeOrganizationId,
+        pending.before.budgetLine,
+        pending.before.direction,
+        pending.before.amount,
+      );
+      await writeAuditEntry(
+        'delete',
+        pending.transactionId,
+        pending.transactionTitle,
+        pending.before,
+        null,
+      );
+    }
+    await deleteDoc(pendingRef);
+  };
+
+  const rejectPendingChange = async (pendingId: string) => {
+    if (!activeOrganizationId) return;
+    const pendingRef = doc(
+      db,
+      'clubs',
+      activeOrganizationId,
+      'pendingChanges',
+      pendingId,
+    );
+    await deleteDoc(pendingRef);
   };
 
   const updateBudgetAllocations = async (allocations: BudgetAllocations) => {
@@ -311,6 +407,7 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
 
   const value: LedgerContextValue = {
     auditLog,
+    pendingChanges,
     organizations,
     addOrganization,
     activeOrganizationId,
@@ -320,6 +417,8 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
     addTransaction,
     updateTransaction,
     deleteTransaction,
+    approvePendingChange,
+    rejectPendingChange,
     updateBudgetAllocations,
     initializeBudgetAllocations,
     selectedBudgetLine,

--- a/src/context/LedgerContext.tsx
+++ b/src/context/LedgerContext.tsx
@@ -263,6 +263,13 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
       before: toFirestore(omitId(old)),
       after: toFirestore(transaction),
     });
+    await writeAuditEntry(
+      'request_edit',
+      id,
+      transaction.title,
+      omitId(old),
+      transaction,
+    );
   };
 
   const deleteTransaction = async (id: string) => {
@@ -281,6 +288,7 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
       before: toFirestore(omitId(old)),
       after: null,
     });
+    await writeAuditEntry('request_delete', id, old.title, omitId(old), null);
   };
 
   const approvePendingChange = async (pendingId: string) => {
@@ -293,6 +301,13 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
       activeOrganizationId,
       'pendingChanges',
       pendingId,
+    );
+    await writeAuditEntry(
+      'approve',
+      pending.transactionId,
+      pending.transactionTitle,
+      pending.before,
+      pending.after,
     );
     if (pending.type === 'edit' && pending.after) {
       const txnRef = doc(
@@ -315,13 +330,6 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
         pending.after.direction,
         pending.after.amount,
       );
-      await writeAuditEntry(
-        'edit',
-        pending.transactionId,
-        pending.transactionTitle,
-        pending.before,
-        pending.after,
-      );
     } else if (pending.type === 'delete') {
       const txnRef = doc(
         db,
@@ -337,19 +345,13 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
         pending.before.direction,
         pending.before.amount,
       );
-      await writeAuditEntry(
-        'delete',
-        pending.transactionId,
-        pending.transactionTitle,
-        pending.before,
-        null,
-      );
     }
     await deleteDoc(pendingRef);
   };
 
   const rejectPendingChange = async (pendingId: string) => {
     if (!activeOrganizationId) return;
+    const pending = pendingChanges.find((p) => p.id === pendingId);
     const pendingRef = doc(
       db,
       'clubs',
@@ -358,6 +360,15 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
       pendingId,
     );
     await deleteDoc(pendingRef);
+    if (pending) {
+      await writeAuditEntry(
+        'reject',
+        pending.transactionId,
+        pending.transactionTitle,
+        pending.before,
+        pending.after,
+      );
+    }
   };
 
   const updateBudgetAllocations = async (allocations: BudgetAllocations) => {

--- a/src/hooks/useRole.ts
+++ b/src/hooks/useRole.ts
@@ -11,7 +11,7 @@ export const useRole = (): UserRole | null => {
   const email = user.email;
   if (activeOrganization.treasurer === email) return 'treasurer';
   if (activeOrganization.president === email) return 'president';
-  if (activeOrganization.execs?.includes(email)) return 'exec';
+  if (activeOrganization.officers?.includes(email)) return 'officer';
 
   // Backwards compat: existing orgs only have admins[] — treat them as treasurer
   if (activeOrganization.admins?.includes(email)) return 'treasurer';

--- a/src/hooks/useRole.ts
+++ b/src/hooks/useRole.ts
@@ -1,0 +1,20 @@
+import { UserRole } from '../types';
+import { useAuth } from './useAuth';
+import { useLedger } from './useLedger';
+
+export const useRole = (): UserRole | null => {
+  const { user } = useAuth();
+  const { activeOrganization } = useLedger();
+
+  if (!user?.email || !activeOrganization) return null;
+
+  const email = user.email;
+  if (activeOrganization.treasurer === email) return 'treasurer';
+  if (activeOrganization.president === email) return 'president';
+  if (activeOrganization.execs?.includes(email)) return 'exec';
+
+  // Backwards compat: existing orgs only have admins[] — treat them as treasurer
+  if (activeOrganization.admins?.includes(email)) return 'treasurer';
+
+  return null;
+};

--- a/src/pages/AuditLogPage.tsx
+++ b/src/pages/AuditLogPage.tsx
@@ -27,11 +27,39 @@ const actionLabel = (action: AuditEntry['action']) => {
       className: 'wl-audit-badge--edit',
       entryClass: 'wl-audit-entry--edit',
     };
+  if (action === 'delete')
+    return {
+      label: 'Deleted',
+      icon: '×',
+      className: 'wl-audit-badge--delete',
+      entryClass: 'wl-audit-entry--delete',
+    };
+  if (action === 'request_edit')
+    return {
+      label: 'Edit Requested',
+      icon: '?',
+      className: 'wl-audit-badge--request',
+      entryClass: 'wl-audit-entry--request',
+    };
+  if (action === 'request_delete')
+    return {
+      label: 'Delete Requested',
+      icon: '?',
+      className: 'wl-audit-badge--request',
+      entryClass: 'wl-audit-entry--request',
+    };
+  if (action === 'approve')
+    return {
+      label: 'Approved',
+      icon: '✓',
+      className: 'wl-audit-badge--approve',
+      entryClass: 'wl-audit-entry--approve',
+    };
   return {
-    label: 'Deleted',
-    icon: '×',
-    className: 'wl-audit-badge--delete',
-    entryClass: 'wl-audit-entry--delete',
+    label: 'Rejected',
+    icon: '✕',
+    className: 'wl-audit-badge--reject',
+    entryClass: 'wl-audit-entry--reject',
   };
 };
 
@@ -112,7 +140,11 @@ export const AuditLogPage = () => {
             {auditLog.map((entry) => {
               const { label, icon, className, entryClass } = actionLabel(entry.action);
               const changedKeys =
-                entry.action === 'edit' && entry.before && entry.after
+                (entry.action === 'edit' ||
+                  entry.action === 'request_edit' ||
+                  entry.action === 'approve') &&
+                entry.before &&
+                entry.after
                   ? Object.keys(entry.after).filter(
                       (k) =>
                         (entry.before as Record<string, unknown>)[k] !==

--- a/src/pages/DashboardOptionB.tsx
+++ b/src/pages/DashboardOptionB.tsx
@@ -15,7 +15,9 @@ export const DashboardOptionB = () => {
     selectedBudgetLine,
     setSelectedBudgetLine,
     activeOrganization,
+    userRole,
   } = useLedger();
+  const canEdit = userRole === 'treasurer' || userRole === 'president';
 
   useEffect(() => {
     if (activeOrganization === null) {
@@ -85,13 +87,15 @@ export const DashboardOptionB = () => {
             >
               Audit History
             </button>
-            <button
-              type="button"
-              className="wl-sidebar-add-btn"
-              onClick={() => setModalOpen(true)}
-            >
-              + Add Transaction
-            </button>
+            {canEdit && (
+              <button
+                type="button"
+                className="wl-sidebar-add-btn"
+                onClick={() => setModalOpen(true)}
+              >
+                + Add Transaction
+              </button>
+            )}
           </div>
         </aside>
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -13,7 +13,8 @@ const EMPTY_ALLOCATIONS: BudgetAllocations = {
 };
 
 export const Settings = () => {
-  const { activeOrganization, updateBudgetAllocations } = useLedger();
+  const { activeOrganization, updateBudgetAllocations, userRole } = useLedger();
+  const canEdit = userRole !== 'exec';
   const navigate = useNavigate();
 
   const [allocations, setAllocations] = useState<BudgetAllocations>(
@@ -103,7 +104,9 @@ export const Settings = () => {
                 color: 'var(--color-text-muted)',
               }}
             >
-              Adjust your club&apos;s starting budget amounts for each line.
+              {canEdit
+                ? "Adjust your club's starting budget amounts for each line."
+                : 'You have read-only access to budget allocations.'}
             </p>
 
             <div className="wl-budget-allocation-form">
@@ -125,6 +128,7 @@ export const Settings = () => {
                       value={rawInputs[line] ?? allocations[line]}
                       placeholder="0.00"
                       onChange={(e) => setAllocation(line, e.target.value)}
+                      disabled={!canEdit}
                     />
                   </div>
                   <span className="wl-budget-allocation-preview">
@@ -155,32 +159,34 @@ export const Settings = () => {
               </div>
             )}
 
-            <div
-              style={{
-                display: 'flex',
-                gap: 12,
-                marginTop: 20,
-                paddingTop: 16,
-                borderTop: '1.5px solid var(--color-border)',
-              }}
-            >
-              <button
-                type="button"
-                className="wl-btn-primary"
-                onClick={handleSave}
-                disabled={submitting}
+            {canEdit && (
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 12,
+                  marginTop: 20,
+                  paddingTop: 16,
+                  borderTop: '1.5px solid var(--color-border)',
+                }}
               >
-                {submitting ? 'Saving…' : 'Save Changes'}
-              </button>
-              <button
-                type="button"
-                className="wl-btn-cancel"
-                onClick={handleReset}
-                disabled={submitting}
-              >
-                Reset to $0
-              </button>
-            </div>
+                <button
+                  type="button"
+                  className="wl-btn-primary"
+                  onClick={handleSave}
+                  disabled={submitting}
+                >
+                  {submitting ? 'Saving…' : 'Save Changes'}
+                </button>
+                <button
+                  type="button"
+                  className="wl-btn-cancel"
+                  onClick={handleReset}
+                  disabled={submitting}
+                >
+                  Reset to $0
+                </button>
+              </div>
+            )}
           </div>
         </section>
       </main>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -14,7 +14,7 @@ const EMPTY_ALLOCATIONS: BudgetAllocations = {
 
 export const Settings = () => {
   const { activeOrganization, updateBudgetAllocations, userRole } = useLedger();
-  const canEdit = userRole !== 'exec';
+  const canEdit = userRole === 'treasurer' || userRole === 'president';
   const navigate = useNavigate();
 
   const [allocations, setAllocations] = useState<BudgetAllocations>(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,10 +59,15 @@ export interface OverallSummaryData {
 
 export type BudgetAllocations = Record<BudgetLine, number>;
 
+export type UserRole = 'treasurer' | 'president' | 'exec';
+
 export interface Organization {
   id: string;
   name: string;
   admins: string[];
+  treasurer?: string;
+  president?: string;
+  execs?: string[];
   budgetAllocations: BudgetAllocations;
   isBudgetLinesSet: boolean;
   transactions: Transaction[];
@@ -75,6 +80,7 @@ export interface LedgerContextValue {
   activeOrganizationId: string | null;
   setActiveOrganizationId: (id: string) => void;
   activeOrganization: Organization | null;
+  userRole: UserRole | null;
   addTransaction: (transaction: Omit<Transaction, 'id'>) => Promise<void>;
   updateTransaction: (id: string, transaction: Omit<Transaction, 'id'>) => Promise<void>;
   deleteTransaction: (id: string) => Promise<void>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,18 @@ export interface OverallSummaryData {
 
 export type BudgetAllocations = Record<BudgetLine, number>;
 
+export interface PendingChange {
+  id: string;
+  type: 'edit' | 'delete';
+  transactionId: string;
+  transactionTitle: string;
+  requestedBy: string;
+  requestedByRole: 'treasurer' | 'president';
+  requestedAt: number;
+  before: Omit<Transaction, 'id'>;
+  after: Omit<Transaction, 'id'> | null;
+}
+
 export type UserRole = 'treasurer' | 'president' | 'officer';
 
 export interface Organization {
@@ -75,6 +87,7 @@ export interface Organization {
 
 export interface LedgerContextValue {
   auditLog: AuditEntry[];
+  pendingChanges: PendingChange[];
   organizations: Organization[];
   addOrganization: (name: string, budgetAllocations: BudgetAllocations) => Promise<void>;
   activeOrganizationId: string | null;
@@ -84,6 +97,8 @@ export interface LedgerContextValue {
   addTransaction: (transaction: Omit<Transaction, 'id'>) => Promise<void>;
   updateTransaction: (id: string, transaction: Omit<Transaction, 'id'>) => Promise<void>;
   deleteTransaction: (id: string) => Promise<void>;
+  approvePendingChange: (pendingId: string) => Promise<void>;
+  rejectPendingChange: (pendingId: string) => Promise<void>;
   updateBudgetAllocations: (allocations: BudgetAllocations) => Promise<void>;
   initializeBudgetAllocations: (allocations: BudgetAllocations) => Promise<void>;
   selectedBudgetLine: BudgetLine | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,7 +31,14 @@ export interface Transaction {
   conflictOfInterestFileName?: string;
 }
 
-export type AuditAction = 'create' | 'edit' | 'delete';
+export type AuditAction =
+  | 'create'
+  | 'edit'
+  | 'delete'
+  | 'request_edit'
+  | 'request_delete'
+  | 'approve'
+  | 'reject';
 
 export interface AuditEntry {
   id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,15 +59,15 @@ export interface OverallSummaryData {
 
 export type BudgetAllocations = Record<BudgetLine, number>;
 
-export type UserRole = 'treasurer' | 'president' | 'exec';
+export type UserRole = 'treasurer' | 'president' | 'officer';
 
 export interface Organization {
   id: string;
   name: string;
   admins: string[];
-  treasurer?: string;
-  president?: string;
-  execs?: string[];
+  treasurer?: string[];
+  president?: string[];
+  officers?: string[];
   budgetAllocations: BudgetAllocations;
   isBudgetLinesSet: boolean;
   transactions: Transaction[];


### PR DESCRIPTION
- Officers can view transactions but cannot add, edit, or delete
- Treasurer and president must cross-approve each other's edit/delete requests before changes take effect
- Pending changes show inline on the transaction with approve/reject actions for the other party
- Audit history tracks the full lifecycle: create, edit request, approval/rejection, and delete