### PR TITLE
show delete confirmation inline below its transaction row with slide-down animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1450,6 +1450,33 @@ tbody tr:last-child .wl-td {
   margin: 0 0 10px;
 }
 
+@keyframes wl-slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.wl-delete-confirm-row td {
+  padding: 0 !important;
+  border-top: none !important;
+}
+
+.wl-delete-confirm-cell {
+  padding: 0 !important;
+}
+
+.wl-inline-confirm--inline {
+  margin: 0;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+  border-top: none;
+  animation: wl-slide-down 0.2s ease-out forwards;
+}
+
 /* ─── Status badges ──────────────────────────────────────────────── */
 .wl-badge {
   display: inline-block;

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 import { auth } from '../config/firebase';
 import { useLedger } from '../hooks/useLedger';
@@ -142,47 +142,51 @@ export const TransactionList = () => {
             </thead>
             <tbody>
               {filteredTransactions.map((t) => (
-                <TransactionRow
-                  key={t.id}
-                  t={t}
-                  canEdit={canEdit}
-                  pending={pendingChanges.find((p) => p.transactionId === t.id)}
-                  onEdit={setEditingTransaction}
-                  onDelete={setDeletingTransaction}
-                  onApprove={approvePendingChange}
-                  onReject={rejectPendingChange}
-                />
+                <React.Fragment key={t.id}>
+                  <TransactionRow
+                    t={t}
+                    canEdit={canEdit}
+                    pending={pendingChanges.find((p) => p.transactionId === t.id)}
+                    onEdit={setEditingTransaction}
+                    onDelete={setDeletingTransaction}
+                    onApprove={approvePendingChange}
+                    onReject={rejectPendingChange}
+                  />
+                  {deletingTransaction?.id === t.id && (
+                    <tr className="wl-delete-confirm-row">
+                      <td colSpan={canEdit ? 5 : 4} className="wl-delete-confirm-cell">
+                        <div className="wl-inline-confirm wl-inline-confirm--inline">
+                          <p>
+                            Submit a delete request for <strong>{t.title}</strong>? The
+                            other approver will need to confirm before it is removed.
+                          </p>
+                          <div className="wl-overdraft-actions">
+                            <button
+                              type="button"
+                              className="wl-btn-warning"
+                              style={{ background: '#dc2626' }}
+                              onClick={handleDeleteConfirm}
+                            >
+                              Submit Request
+                            </button>
+                            <button
+                              type="button"
+                              className="wl-btn-cancel"
+                              onClick={() => setDeletingTransaction(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>
         </div>
       </div>
-
-      {deletingTransaction && (
-        <div className="wl-inline-confirm">
-          <p>
-            Submit a delete request for <strong>{deletingTransaction.title}</strong>? The
-            other approver will need to confirm before it is removed.
-          </p>
-          <div className="wl-overdraft-actions">
-            <button
-              type="button"
-              className="wl-btn-warning"
-              style={{ background: '#dc2626' }}
-              onClick={handleDeleteConfirm}
-            >
-              Submit Request
-            </button>
-            <button
-              type="button"
-              className="wl-btn-cancel"
-              onClick={() => setDeletingTransaction(null)}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
 
       <TransactionModal
         isOpen={!!editingTransaction}


### PR DESCRIPTION
Problem:
Delete confirmation appeared at the bottom of the full transaction list, forcing users to scroll past all transactions to find it.
Solution:
Confirmation now slides in inline directly below the clicked transaction row