### PR TITLE
replace X delete button with trash can icon

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -87,7 +87,23 @@ const TransactionRow = ({
                 onClick={() => onDelete(t)}
                 aria-label="Delete transaction"
               >
-                ✕
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                </svg>
               </button>
             </>
           )}


### PR DESCRIPTION
Problem: The delete button used a plain X character, which is ambiguous and easy to confuse with a close/dismiss action.

Solution: Replaced the X with a recognizable inline trash can SVG icon 