### PR TITLE
Fix navigation: restore original dashboard header and back buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2325,23 +2325,3 @@ tbody tr:last-child .wl-td {
 .wl-topnav-offset {
   padding-top: 64px;
 }
-
-.wl-topnav-left {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-}
-
-.wl-topnav-back {
-  background: none;
-  border: none;
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 0.78rem;
-  cursor: pointer;
-  padding: 0 8px;
-  transition: color 0.15s;
-}
-.wl-topnav-back:hover {
-  color: #fff;
-}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -7,25 +7,15 @@ export const TopNav = () => {
 
   return (
     <nav className="wl-topnav">
-      <div className="wl-topnav-left">
-        <button
-          type="button"
-          className="wl-topnav-logo"
-          onClick={() => navigate('/organizations')}
-          aria-label="Go to home"
-        >
-          <img src={logo} alt="WildcatLedger" className="wl-topnav-logo-img" />
-          <span className="wl-topnav-logo-text">WildcatLedger</span>
-        </button>
-        <button
-          type="button"
-          className="wl-topnav-back"
-          onClick={() => navigate(-1)}
-          aria-label="Go back"
-        >
-          ← Back
-        </button>
-      </div>
+      <button
+        type="button"
+        className="wl-topnav-logo"
+        onClick={() => navigate('/organizations')}
+        aria-label="Go to home"
+      >
+        <img src={logo} alt="WildcatLedger" className="wl-topnav-logo-img" />
+        <span className="wl-topnav-logo-text">WildcatLedger</span>
+      </button>
     </nav>
   );
 };

--- a/src/pages/AuditLogPage.tsx
+++ b/src/pages/AuditLogPage.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-
 import { TopNav } from '../components/TopNav';
 import { useLedger } from '../hooks/useLedger';
 import { AuditEntry } from '../types';
@@ -105,19 +103,11 @@ const EditDiff = ({
 
 export const AuditLogPage = () => {
   const { auditLog, activeOrganization } = useLedger();
-  const navigate = useNavigate();
 
   return (
     <div className="wl-app">
       <TopNav />
       <div className="wl-main" style={{ marginTop: 64, paddingTop: 24 }}>
-        <button
-          type="button"
-          className="wl-btn-back"
-          onClick={() => navigate('/dashboard')}
-        >
-          ← Back to Dashboard
-        </button>
         <div className="wl-audit-heading-row">
           <h2 className="wl-audit-heading">Audit Log</h2>
           {activeOrganization && (

--- a/src/pages/DashboardOptionB.tsx
+++ b/src/pages/DashboardOptionB.tsx
@@ -53,16 +53,6 @@ export const DashboardOptionB = () => {
       <div className="wl-dashboard-optionB">
         {/* Sidebar */}
         <aside className="wl-sidebar-optionB">
-          <div className="wl-sidebar-header-optionB">
-            <button
-              type="button"
-              className="wl-btn-back"
-              onClick={() => navigate('/organizations')}
-            >
-              ← Back
-            </button>
-          </div>
-
           <div className="wl-sidebar-section-optionB">
             <h3 className="wl-sidebar-title-optionB">Filter</h3>
             <button

--- a/src/pages/DashboardOptionB.tsx
+++ b/src/pages/DashboardOptionB.tsx
@@ -51,6 +51,15 @@ export const DashboardOptionB = () => {
       <div className="wl-dashboard-optionB">
         {/* Sidebar */}
         <aside className="wl-sidebar-optionB">
+          <div className="wl-sidebar-header-optionB">
+            <button
+              type="button"
+              className="wl-btn-back"
+              onClick={() => navigate('/organizations')}
+            >
+              ← Back
+            </button>
+          </div>
           <div className="wl-sidebar-section-optionB">
             <h3 className="wl-sidebar-title-optionB">Filter</h3>
             <button

--- a/src/pages/DashboardOptionB.tsx
+++ b/src/pages/DashboardOptionB.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { TopNav } from '../components/TopNav';
 import { TransactionList } from '../components/TransactionList';
 import { TransactionModal } from '../components/TransactionModal';
 import { useLedger } from '../hooks/useLedger';
@@ -34,8 +33,7 @@ export const DashboardOptionB = () => {
 
   return (
     <div className="wl-app">
-      <TopNav />
-      <div className="wl-header-optionB" style={{ marginTop: 64 }}>
+      <div className="wl-header-optionB">
         <div className="wl-header-optionB-left">
           <h1 className="wl-header-title">{activeOrganization?.name}</h1>
         </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -64,19 +64,7 @@ export const Settings = () => {
   return (
     <div className="wl-app">
       <TopNav />
-      <div
-        className="wl-main"
-        style={{ marginTop: 64, paddingBottom: 0, paddingTop: 16 }}
-      >
-        <button
-          type="button"
-          className="wl-btn-back"
-          onClick={() => navigate('/dashboard')}
-        >
-          ← Back to Dashboard
-        </button>
-      </div>
-      <main className="wl-main">
+      <main className="wl-main" style={{ marginTop: 64 }}>
         <section>
           <h1
             className="wl-section-title"

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -64,7 +64,19 @@ export const Settings = () => {
   return (
     <div className="wl-app">
       <TopNav />
-      <main className="wl-main" style={{ marginTop: 64 }}>
+      <div
+        className="wl-main"
+        style={{ marginTop: 64, paddingBottom: 0, paddingTop: 16 }}
+      >
+        <button
+          type="button"
+          className="wl-btn-back"
+          onClick={() => navigate('/dashboard')}
+        >
+          ← Back to Dashboard
+        </button>
+      </div>
+      <main className="wl-main">
         <section>
           <h1
             className="wl-section-title"


### PR DESCRIPTION
## Summary
- Remove TopNav from dashboard — restores original purple club-name header
- Remove duplicate back buttons that appeared after TopNav was added
- Restore back button in dashboard sidebar (← Back to organizations)
- Restore back button on Settings page (← Back to Dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)