### PR TITLE
add pending change cancellation and view details toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1319,6 +1319,98 @@ tbody tr:hover:not(.wl-row--flagged) {
   gap: 6px;
 }
 
+.wl-btn-view-details {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.wl-btn-view-details:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.wl-pending-detail-row {
+  background: #fffbeb;
+}
+
+.wl-pending-detail-cell {
+  padding: 10px 16px 14px;
+  border-bottom: 1px solid #fde68a;
+}
+
+.wl-pending-detail-delete {
+  font-size: 0.85rem;
+  color: #92400e;
+  margin: 0;
+}
+
+.wl-pending-detail-diff {
+  display: flex;
+  gap: 16px;
+}
+
+.wl-pending-detail-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: #fff;
+  border-radius: 6px;
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+}
+
+.wl-pending-detail-col--after {
+  border-color: #a7f3d0;
+  background: #f0fdf4;
+}
+
+.wl-pending-detail-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin-bottom: 2px;
+}
+
+.wl-pending-detail-col--after .wl-pending-detail-label {
+  color: #065f46;
+}
+
+.wl-pending-detail-row-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.82rem;
+}
+
+.wl-pending-detail-field {
+  color: var(--color-text-muted);
+  min-width: 70px;
+  font-size: 0.78rem;
+}
+
+.wl-pending-detail-value--before {
+  color: var(--color-text);
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+
+.wl-pending-detail-value--after {
+  color: #065f46;
+  font-weight: 600;
+}
+
 .wl-btn-approve {
   background: var(--color-positive);
   color: #fff;
@@ -1651,6 +1743,15 @@ tbody tr:last-child .wl-td {
 .wl-audit-badge--reject {
   background: #fee2e2;
   color: #991b1b;
+}
+
+.wl-audit-badge--cancel {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.wl-audit-entry--cancel {
+  border-left-color: #9ca3af;
 }
 
 .wl-audit-title {

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -14,6 +14,7 @@ const TransactionRow = ({
   onDelete,
   onApprove,
   onReject,
+  onCancel,
 }: {
   t: Transaction;
   canEdit: boolean;
@@ -22,94 +23,162 @@ const TransactionRow = ({
   onDelete: (t: Transaction) => void;
   onApprove: (pendingId: string) => void;
   onReject: (pendingId: string) => void;
+  onCancel: (pendingId: string) => void;
 }) => {
+  const [showDetail, setShowDetail] = useState(false);
   const isInflow = t.direction === 'Inflow';
   const currentEmail = auth.currentUser?.email;
   const isMyPending = !!pending && pending.requestedBy === currentEmail;
   const canApprove = !!pending && !isMyPending && canEdit;
+  const colSpan = canEdit ? 5 : 4;
+
+  const changedKeys =
+    pending?.type === 'edit' && pending.before && pending.after
+      ? Object.keys(pending.after).filter(
+          (k) =>
+            (pending.before as Record<string, unknown>)[k] !==
+            (pending.after as Record<string, unknown>)[k],
+        )
+      : [];
 
   return (
-    <tr className={pending ? 'wl-row--pending' : ''}>
-      <td className="wl-td wl-td-title">
-        <span className="wl-td-title-text">{t.title}</span>
-        {pending && (
-          <span className="wl-pending-type-badge">
-            {pending.type === 'delete' ? 'Delete requested' : 'Edit requested'}
-          </span>
-        )}
-      </td>
-      <td
-        className={`wl-td wl-td-amount ${isInflow ? 'wl-amount-positive' : 'wl-amount-negative'}`}
-      >
-        {isInflow ? '+' : '-'}
-        {formatCurrency(t.amount)}
-      </td>
-      <td className="wl-td wl-td-type">{t.type}</td>
-      <td className="wl-td wl-td-budget">
-        <span className="wl-budget-chip">{t.budgetLine}</span>
-      </td>
-      {canEdit && (
-        <td className="wl-td wl-td-actions">
-          {pending ? (
-            isMyPending ? (
-              <span className="wl-pending-badge">Awaiting Approval</span>
-            ) : canApprove ? (
-              <div className="wl-approve-actions">
-                <button
-                  type="button"
-                  className="wl-btn-approve"
-                  onClick={() => onApprove(pending.id)}
-                >
-                  Approve
-                </button>
-                <button
-                  type="button"
-                  className="wl-btn-reject"
-                  onClick={() => onReject(pending.id)}
-                >
-                  Reject
-                </button>
-              </div>
-            ) : null
-          ) : (
-            <>
-              <button
-                type="button"
-                className="wl-action-btn"
-                onClick={() => onEdit(t)}
-                aria-label="Edit transaction"
-              >
-                ✎
-              </button>
-              <button
-                type="button"
-                className="wl-action-btn wl-action-btn--delete"
-                onClick={() => onDelete(t)}
-                aria-label="Delete transaction"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="15"
-                  height="15"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="3 6 5 6 21 6" />
-                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                  <path d="M10 11v6" />
-                  <path d="M14 11v6" />
-                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                </svg>
-              </button>
-            </>
+    <>
+      <tr className={pending ? 'wl-row--pending' : ''}>
+        <td className="wl-td wl-td-title">
+          <span className="wl-td-title-text">{t.title}</span>
+          {pending && (
+            <span className="wl-pending-type-badge">
+              {pending.type === 'delete' ? 'Delete requested' : 'Edit requested'}
+            </span>
           )}
         </td>
+        <td
+          className={`wl-td wl-td-amount ${isInflow ? 'wl-amount-positive' : 'wl-amount-negative'}`}
+        >
+          {isInflow ? '+' : '-'}
+          {formatCurrency(t.amount)}
+        </td>
+        <td className="wl-td wl-td-type">{t.type}</td>
+        <td className="wl-td wl-td-budget">
+          <span className="wl-budget-chip">{t.budgetLine}</span>
+        </td>
+        {canEdit && (
+          <td className="wl-td wl-td-actions">
+            {pending ? (
+              isMyPending ? (
+                <div className="wl-approve-actions">
+                  <span className="wl-pending-badge">Awaiting Approval</span>
+                  <button
+                    type="button"
+                    className="wl-btn-reject"
+                    onClick={() => onCancel(pending.id)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : canApprove ? (
+                <div className="wl-approve-actions">
+                  {pending.type === 'edit' && (
+                    <button
+                      type="button"
+                      className="wl-btn-view-details"
+                      onClick={() => setShowDetail((v) => !v)}
+                    >
+                      {showDetail ? 'Hide' : 'View details'}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="wl-btn-approve"
+                    onClick={() => onApprove(pending.id)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    className="wl-btn-reject"
+                    onClick={() => onReject(pending.id)}
+                  >
+                    Reject
+                  </button>
+                </div>
+              ) : null
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="wl-action-btn"
+                  onClick={() => onEdit(t)}
+                  aria-label="Edit transaction"
+                >
+                  ✎
+                </button>
+                <button
+                  type="button"
+                  className="wl-action-btn wl-action-btn--delete"
+                  onClick={() => onDelete(t)}
+                  aria-label="Delete transaction"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                    <path d="M10 11v6" />
+                    <path d="M14 11v6" />
+                    <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                  </svg>
+                </button>
+              </>
+            )}
+          </td>
+        )}
+      </tr>
+      {canApprove && showDetail && (
+        <tr className="wl-pending-detail-row">
+          <td colSpan={colSpan} className="wl-pending-detail-cell">
+            {pending.type === 'delete' ? (
+              <p className="wl-pending-detail-delete">
+                This transaction will be <strong>permanently deleted</strong> if approved.
+              </p>
+            ) : changedKeys.length > 0 ? (
+              <div className="wl-pending-detail-diff">
+                <div className="wl-pending-detail-col wl-pending-detail-col--before">
+                  <span className="wl-pending-detail-label">Before</span>
+                  {changedKeys.map((k) => (
+                    <div key={k} className="wl-pending-detail-row-item">
+                      <span className="wl-pending-detail-field">{k}</span>
+                      <span className="wl-pending-detail-value wl-pending-detail-value--before">
+                        {String((pending.before as Record<string, unknown>)[k] ?? '—')}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <div className="wl-pending-detail-col wl-pending-detail-col--after">
+                  <span className="wl-pending-detail-label">After</span>
+                  {changedKeys.map((k) => (
+                    <div key={k} className="wl-pending-detail-row-item">
+                      <span className="wl-pending-detail-field">{k}</span>
+                      <span className="wl-pending-detail-value wl-pending-detail-value--after">
+                        {String((pending.after as Record<string, unknown>)[k] ?? '—')}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </td>
+        </tr>
       )}
-    </tr>
+    </>
   );
 };
 
@@ -121,6 +190,7 @@ export const TransactionList = () => {
     pendingChanges,
     approvePendingChange,
     rejectPendingChange,
+    cancelPendingChange,
   } = useLedger();
   const canEdit = userRole === 'treasurer' || userRole === 'president';
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
@@ -167,6 +237,7 @@ export const TransactionList = () => {
                     onDelete={setDeletingTransaction}
                     onApprove={approvePendingChange}
                     onReject={rejectPendingChange}
+                    onCancel={cancelPendingChange}
                   />
                   {deletingTransaction?.id === t.id && (
                     <tr className="wl-delete-confirm-row">

--- a/src/context/LedgerContext.tsx
+++ b/src/context/LedgerContext.tsx
@@ -371,6 +371,28 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  const cancelPendingChange = async (pendingId: string) => {
+    if (!activeOrganizationId) return;
+    const pending = pendingChanges.find((p) => p.id === pendingId);
+    const pendingRef = doc(
+      db,
+      'clubs',
+      activeOrganizationId,
+      'pendingChanges',
+      pendingId,
+    );
+    await deleteDoc(pendingRef);
+    if (pending) {
+      await writeAuditEntry(
+        'cancel',
+        pending.transactionId,
+        pending.transactionTitle,
+        pending.before,
+        pending.after,
+      );
+    }
+  };
+
   const updateBudgetAllocations = async (allocations: BudgetAllocations) => {
     if (!activeOrganizationId) return;
     const orgRef = doc(db, 'clubs', activeOrganizationId);
@@ -430,6 +452,7 @@ export const LedgerProvider = ({ children }: { children: React.ReactNode }) => {
     deleteTransaction,
     approvePendingChange,
     rejectPendingChange,
+    cancelPendingChange,
     updateBudgetAllocations,
     initializeBudgetAllocations,
     selectedBudgetLine,

--- a/src/pages/AuditLogPage.tsx
+++ b/src/pages/AuditLogPage.tsx
@@ -56,11 +56,18 @@ const actionLabel = (action: AuditEntry['action'], after: AuditEntry['after']) =
       className: 'wl-audit-badge--approve',
       entryClass: 'wl-audit-entry--approve',
     };
+  if (action === 'reject')
+    return {
+      label: 'Rejected',
+      icon: '✕',
+      className: 'wl-audit-badge--reject',
+      entryClass: 'wl-audit-entry--reject',
+    };
   return {
-    label: after === null ? 'Rejected Delete' : 'Rejected Edit',
-    icon: '✕',
-    className: 'wl-audit-badge--reject',
-    entryClass: 'wl-audit-entry--reject',
+    label: 'Cancelled',
+    icon: '↩',
+    className: 'wl-audit-badge--cancel',
+    entryClass: 'wl-audit-entry--cancel',
   };
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,8 @@ export type AuditAction =
   | 'request_edit'
   | 'request_delete'
   | 'approve'
-  | 'reject';
+  | 'reject'
+  | 'cancel';
 
 export interface AuditEntry {
   id: string;
@@ -106,6 +107,7 @@ export interface LedgerContextValue {
   deleteTransaction: (id: string) => Promise<void>;
   approvePendingChange: (pendingId: string) => Promise<void>;
   rejectPendingChange: (pendingId: string) => Promise<void>;
+  cancelPendingChange: (pendingId: string) => Promise<void>;
   updateBudgetAllocations: (allocations: BudgetAllocations) => Promise<void>;
   initializeBudgetAllocations: (allocations: BudgetAllocations) => Promise<void>;
   selectedBudgetLine: BudgetLine | null;


### PR DESCRIPTION
- Approving user can now view details of a transaction edit
- "View details" and "Hide details" buttons added to toggle details on a transaction edit
- Requesting user can cancel a transaction edit they made